### PR TITLE
fixed links in contribution.md (gh#48)

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -12,13 +12,14 @@ Bug Reports
 -----------
 
 If you find a problem, please report it either using
-[Bugzilla](https://bugzilla.novell.com/enter_bug.cgi?format=guided&product=openSUSE+Factory&component=YaST2)
-or [GitHub issues](../../issues). (For Bugzilla, use the [simplified
+[Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?format=guided&product=openSUSE+Factory&component=YaST2)
+or via the [GitHub issues](https://guides.github.com/features/issues/) for the
+specific YaST repository. (For Bugzilla, use the [simplified
 registration](https://secure-www.novell.com/selfreg/jsp/createSimpleAccount.jsp)
 if you don't have an account yet.)
 
 If you find a problem, please report it either using
-[Bugzilla](https://bugzilla.novell.com/) or GitHub issues. We can't guarantee
+[Bugzilla](https://bugzilla.suse.com/) or GitHub issues. We can't guarantee
 that every bug will be fixed, but we'll try.
 
 When creating a bug report, please follow our [bug reporting


### PR DESCRIPTION
This is a fix for #48.

The links pointed to `bugzilla.novell.com`, after updating them to `bugzilla.suse.com` it works correctly.

The `doc/contribution.md` is a copy of `CONTRIBUTION.md` file, and it was not synced after updating the bugzilla links there.

I wanted to replace the file by a symlink to `CONTRIBUTION.md`, but that's not possible because the GitHub issues link points to `../../issues` which works only when displaying the file at GitHub, at `yastgithubio.readthedocs.org` the link is wrong. (That's the second issue found.)

Therefore I just copied the content from `CONTRIBUTION.md` and fixed the link to GitHub issues to point to a generic GitHub documentation.
