### PR TITLE
Update the TW version release

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -122,7 +122,7 @@ installer.
 
 #### <a name="supported_systems"></a> Supported systems
 
-- openSUSE Tumbleweed (since 201606xx version **FIXME: set the version**)
+- openSUSE Tumbleweed 20160602 or newer
 - openSUSE Leap 42.2 or newer
 - SUSE Linux Enterprise Server/Desktop 12 SP2 or newer
 


### PR DESCRIPTION
The yast2-ruby-bindings package has been updated in 20160602 release, see the [change log](http://download.opensuse.org/tumbleweed/iso/Changes.20160602.txt) and I have manually verified that with `Y2DEBUGGER=1` the debugger starts as expected.