### PR TITLE
add some links why cherry pick is wrong

### DIFF
--- a/.spell.yml
+++ b/.spell.yml
@@ -273,6 +273,7 @@ dictionary:
 - SetDesktopIcon
 - SetModified
 - SHA
+- SHAs
 - simplecov
 - skelcd
 - SLE

--- a/.spell.yml
+++ b/.spell.yml
@@ -272,6 +272,7 @@ dictionary:
 - sda
 - SetDesktopIcon
 - SetModified
+- SHA
 - simplecov
 - skelcd
 - SLE

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -63,12 +63,13 @@ git checkout -b my_fix_master # branch based on master
 git merge origin/SLE-12-GA # to ensure that we use recent branch on remote
 # fix possible conflicts and git commit if needed...
 # if maintenance branch contain its specific commit,
-# then use git revert <commit number> and next time it won't appear
+# then use git revert <commit number> and next time it will not appear
 git push
 ```
 
-When maintenance fix was not requested and made only in master and then mind
-changed, it is still needed to merge back cherry pick used for backporting fix.
+When maintenance fix was not requested and made only in master and then
+requested to backport to maintenance branch, it is still needed to `merge` back
+`cherry-pick` used for backporting fix.
 It is valid only for new branches.
 
 Example how to backport fix and then merge branch back
@@ -106,7 +107,7 @@ Maintenance Fixes Rules
 
 To get all benefits described above, there are few easy rules.
 
-* no cherry-pick for new maintenance branches (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
+* no `cherry-pick` for new maintenance branches (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first
 

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -110,7 +110,7 @@ To get all benefits described above, there are few easy rules.
 * no `cherry-pick` as part of common work-flow. In a nutshell, cherry-picking
   changes the SHA because the commit will get a new parent commit. And with
   different SHAs, it is difficult to find out if all desired commits from the
-  branch are now also in master. For deeper exaplanation see these articles
+  branch are now also in master. For deeper explanation see these articles
   [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -107,7 +107,11 @@ Maintenance Fixes Rules
 
 To get all benefits described above, there are few easy rules.
 
-* no `cherry-pick` as part of common work-flow (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
+* no `cherry-pick` as part of common work-flow. In a nutshell, cherry-picking
+  changes the SHA because the commit will get a new parent commit. And with
+  different SHAs, it is difficult to find out if all desired commits from the
+  branch are now also in master. For deeper exaplanation see these articles
+  [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first
 

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -105,7 +105,8 @@ Maintenance Fixes Rules
 -----------------------
 
 To get all benefits described above, there are few easy rules.
-* no cherry-pick for new maintenance branches
+
+* no cherry-pick for new maintenance branches (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first
 

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -68,8 +68,8 @@ git push
 ```
 
 When maintenance fix was not requested and made only in master and then
-requested to backport to maintenance branch, it is still needed to `merge` back
-`cherry-pick` used for backporting fix.
+requested to backport to a maintenance branch, it is still needed to `merge` back
+the `cherry-pick` used for backporting the fix.
 It is valid only for new branches.
 
 Example how to backport fix and then merge branch back
@@ -107,7 +107,7 @@ Maintenance Fixes Rules
 
 To get all benefits described above, there are few easy rules.
 
-* no `cherry-pick` for new maintenance branches (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
+* no `cherry-pick` as part of common work-flow (for reasons see these articles [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first
 


### PR DESCRIPTION
and also fixes list of rules for maintenance branches as empty line is needed for markdown to recognize it.