### PR TITLE
Use https URL for the Google fonts

### DIFF
--- a/assets/stylesheets/bootstrap.min.css
+++ b/assets/stylesheets/bootstrap.min.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Doppio+One);/*!
+@import url(//fonts.googleapis.com/css?family=Doppio+One);/*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com
  * Copyright 2012-2014 Thomas Park

--- a/assets/stylesheets/bootstrap.min.css
+++ b/assets/stylesheets/bootstrap.min.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Doppio+One);/*!
+@import url(https://fonts.googleapis.com/css?family=Doppio+One);/*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com
  * Copyright 2012-2014 Thomas Park

--- a/bootswatch/bootstrap.css
+++ b/bootswatch/bootstrap.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Doppio+One);
+@import url(//fonts.googleapis.com/css?family=Doppio+One);
 /*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com

--- a/bootswatch/bootstrap.css
+++ b/bootswatch/bootstrap.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Doppio+One);
+@import url(https://fonts.googleapis.com/css?family=Doppio+One);
 /*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com

--- a/bootswatch/bootstrap.min.css
+++ b/bootswatch/bootstrap.min.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Doppio+One);/*!
+@import url(//fonts.googleapis.com/css?family=Doppio+One);/*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com
  * Copyright 2012-2014 Thomas Park

--- a/bootswatch/bootstrap.min.css
+++ b/bootswatch/bootstrap.min.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Doppio+One);/*!
+@import url(https://fonts.googleapis.com/css?family=Doppio+One);/*!
  * bootswatch v3.3.0
  * Homepage: http://bootswatch.com
  * Copyright 2012-2014 Thomas Park

--- a/bootswatch/bootswatch.less
+++ b/bootswatch/bootswatch.less
@@ -1,6 +1,6 @@
 /* Begin Vendor Additions*/
 
-@import url(http://fonts.googleapis.com/css?family=Doppio+One);
+@import url(https://fonts.googleapis.com/css?family=Doppio+One);
 
 .navbar-fixed-top { 
   border-bottom: 1px solid #001f2c !important;

--- a/bootswatch/bootswatch.less
+++ b/bootswatch/bootswatch.less
@@ -1,6 +1,6 @@
 /* Begin Vendor Additions*/
 
-@import url(https://fonts.googleapis.com/css?family=Doppio+One);
+@import url(//fonts.googleapis.com/css?family=Doppio+One);
 
 .navbar-fixed-top { 
   border-bottom: 1px solid #001f2c !important;


### PR DESCRIPTION
See the difference between https://yast.github.io/ and http://yast.github.io/ pages.

This fixes the HTTPS version (https://yast.github.io/), browsers deny loading HTTP content into a HTTPS web page.

