### PR TITLE
Added Sharing Buttons

### DIFF
--- a/.spell.yml
+++ b/.spell.yml
@@ -7,6 +7,7 @@ ignore:
   - 'blog/index.html'
   - '_includes/paging.html'
   - '_includes/head.html'
+  - '_includes/sharing.html'
   - '_layouts/post.html'
   - '_site/**/*'
   - 'blog/categories.html'

--- a/_includes/sharing.html
+++ b/_includes/sharing.html
@@ -1,0 +1,29 @@
+<div class="sharing">
+  <div class="sharing-header">
+    Share this:
+  </div>
+
+  <ul class="sharing-list">
+    <li><a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}"
+      class="sharing-button google-button" rel="nofollow" target="_blank"
+      onclick="window.open('https://plus.google.com/share?url={{ site.url }}{{ page.url }}','gplus','width=500,height=480'); return false;"
+      title="Share on Google+">
+      <span class="fa fa-google-plus fa-fw"></span>Google+</a></li>
+    <li><a href="https://twitter.com/share?text={{ page.title }}&amp;url={{ site.url }}{{ page.url }}"
+      onclick="window.open('https://twitter.com/share?text={{ page.title }}&amp;url={{ site.url }}{{ page.url }}','tw','width=500,height=480'); return false;"
+      class="sharing-button twitter-button" rel="nofollow" target="_blank"
+      title="Share on Twitter">
+      <span class="fa fa-twitter fa-fw"></span>Twitter</a></li>
+    <li><a href="https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}"
+      class="sharing-button facebook-button" rel="nofollow" target="_blank"
+      onclick="window.open('https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}', 'fb', 'width=500,height=480'); return false;"
+      title="Share on Facebook">
+      <span class="fa fa-facebook fa-fw"></span>Facebook</a></li>
+    <li><a href="http://pinterest.com/pin/create/button/?url={{ site.url }}{{ page.url }}&amp;description={{ page.title }}"
+        class="sharing-button pinterest-button" rel="nofollow" target="_blank"
+        onclick="window.open('http://pinterest.com/pin/create/button/?url={{ site.url }}{{ page.url }}&amp;description={{ page.title }}', 'pinterest', 'width=800,height=600'); return false;"
+        title="Share on Pinterest">
+      <span class="fa fa-pinterest fa-fw"></span>Pinterest</a></li>
+  </ul>
+
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,6 +38,11 @@ layout: default
   <div class="post-content" itemprop="articleBody">
     {{ content }}
   </div>
+</article>
+
+  {% if page.share != false %}
+    {% include sharing.html %}
+  {% endif %}
 
   {% if page.comments %}
     <div id="disqus_thread"></div>
@@ -56,4 +61,3 @@ layout: default
     <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
   {% endif %}
 
-</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,24 +40,23 @@ layout: default
   </div>
 </article>
 
-  {% if page.share != false %}
-    {% include sharing.html %}
-  {% endif %}
+{% if page.share != false %}
+  {% include sharing.html %}
+{% endif %}
 
-  {% if page.comments %}
-    <div id="disqus_thread"></div>
-    <script>
-      var disqus_config = function () {
-        // unique ID for Disqus to display the correct thread
-        this.page.url = "http://yast.opensuse.org{{ page.url | relative_url }}";
-      };
-      (function() {  // DON'T EDIT BELOW THIS LINE
-          var d = document, s = d.createElement('script');
-          s.src = '//yast.disqus.com/embed.js';
-          s.setAttribute('data-timestamp', + new Date());
-          (d.head || d.body).appendChild(s);
-      })();
-    </script>
-    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
-  {% endif %}
-
+{% if page.comments %}
+  <div id="disqus_thread"></div>
+  <script>
+    var disqus_config = function () {
+      // unique ID for Disqus to display the correct thread
+      this.page.url = "http://yast.opensuse.org{{ page.url | relative_url }}";
+    };
+    (function() {  // DON'T EDIT BELOW THIS LINE
+        var d = document, s = d.createElement('script');
+        s.src = '//yast.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', + new Date());
+        (d.head || d.body).appendChild(s);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+{% endif %}

--- a/_sass/_sharing.scss
+++ b/_sass/_sharing.scss
@@ -8,22 +8,25 @@ $facebook-button-color: #3b5999;
 // https://business.pinterest.com/en/brand-guidelines
 $pinterest-button-color: #bd081c;
 
+#content-row {
+
 .sharing {
   text-align: center;
-  margin: 4em 0 1em 0;
+  margin: 3em 0 1em;
 }
 
 .sharing-header {
   font-style: italic;
-  font-size: 13px;
-  margin: 10px;
+  font-size: $small-font-size;
+  margin-bottom: 1em;
 }
 
 .sharing-list {
-  margin: 0;
+  padding: 0;
   li {
-    display: inline;
+    display: inline-block;
     list-style: none;
+    line-height: 3em;
     &:not(:last-child) {
       margin-right: 10px;
     }
@@ -31,54 +34,39 @@ $pinterest-button-color: #bd081c;
 }
 
 .sharing-button {
-  font-size: 13px;
-  padding: 4px 8px;
-  border-radius: 6px;
-  &:hover {
-    text-decoration: none;
-  }
+  font-size: $small-font-size;
+  padding: 8px;
+  border-radius: 10px;
+  text-decoration: none;
+  color: white;
 }
 
 .google-button {
   background-color: $google-button;
-  color: white;
   &:hover {
     background-color: lighten($google-button, 10%);
-  }
-  &:visited {
-    color: white;
   }
 }
 
 .twitter-button {
   background-color: $twitter-button-color;
-  color: white;
   &:hover {
     background-color: lighten($twitter-button-color, 10%);
-  }
-  &:visited {
-    color: white;
   }
 }
 
 .facebook-button {
   background-color: $facebook-button-color;
-  color: white;
   &:hover {
     background-color: lighten($facebook-button-color, 10%);
-  }
-  &:visited {
-    color: white;
   }
 }
 
 .pinterest-button {
   background-color: $pinterest-button-color;
-  color: white;
   &:hover {
     background-color: lighten($pinterest-button-color, 10%);
   }
-  &:visited {
-    color: white;
-  }
+}
+
 }

--- a/_sass/_sharing.scss
+++ b/_sass/_sharing.scss
@@ -9,64 +9,62 @@ $facebook-button-color: #3b5999;
 $pinterest-button-color: #bd081c;
 
 #content-row {
+  .sharing {
+    text-align: center;
+    margin: 3em 0 1em;
+  }
 
-.sharing {
-  text-align: center;
-  margin: 3em 0 1em;
-}
+  .sharing-header {
+    font-style: italic;
+    font-size: $small-font-size;
+    margin-bottom: 1em;
+  }
 
-.sharing-header {
-  font-style: italic;
-  font-size: $small-font-size;
-  margin-bottom: 1em;
-}
-
-.sharing-list {
-  padding: 0;
-  li {
-    display: inline-block;
-    list-style: none;
-    line-height: 3em;
-    &:not(:last-child) {
-      margin-right: 10px;
+  .sharing-list {
+    padding: 0;
+    li {
+      display: inline-block;
+      list-style: none;
+      line-height: 3em;
+      &:not(:last-child) {
+        margin-right: 10px;
+      }
     }
   }
-}
 
-.sharing-button {
-  font-size: $small-font-size;
-  padding: 8px;
-  border-radius: 10px;
-  text-decoration: none;
-  color: white;
-}
-
-.google-button {
-  background-color: $google-button;
-  &:hover {
-    background-color: lighten($google-button, 10%);
+  .sharing-button {
+    font-size: $small-font-size;
+    padding: 8px;
+    border-radius: 10px;
+    text-decoration: none;
+    color: white;
   }
-}
 
-.twitter-button {
-  background-color: $twitter-button-color;
-  &:hover {
-    background-color: lighten($twitter-button-color, 10%);
+  .google-button {
+    background-color: $google-button;
+    &:hover {
+      background-color: lighten($google-button, 10%);
+    }
   }
-}
 
-.facebook-button {
-  background-color: $facebook-button-color;
-  &:hover {
-    background-color: lighten($facebook-button-color, 10%);
+  .twitter-button {
+    background-color: $twitter-button-color;
+    &:hover {
+      background-color: lighten($twitter-button-color, 10%);
+    }
   }
-}
 
-.pinterest-button {
-  background-color: $pinterest-button-color;
-  &:hover {
-    background-color: lighten($pinterest-button-color, 10%);
+  .facebook-button {
+    background-color: $facebook-button-color;
+    &:hover {
+      background-color: lighten($facebook-button-color, 10%);
+    }
   }
-}
 
+  .pinterest-button {
+    background-color: $pinterest-button-color;
+    &:hover {
+      background-color: lighten($pinterest-button-color, 10%);
+    }
+  }
 }


### PR DESCRIPTION
- Added G+, FB, TW and Pinterest buttons for easy sharing new blog posts
- The sharing buttons are enabled by default, can be disabled per post via a `share: false` option. (I'll document all these options later...)
- Do the review per commit - check the first commit, the second one is just an indentation (whitespace only) fix
- Deployed at http://blog.ladslezak.cz/blog
- You check the buttons e.g. at the bottom of the http://blog.ladslezak.cz/blog/blog/2016/12/02/highlights-of-yast-development-sprint-28/ page