### PR TITLE
Sticky footer - always displayed at the bottom

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer>
+<footer class="site-footer" >
   <div class="container">
     <div class="row">
       <div class="col-sm-12">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
   {% include head.html %}
 
   <body>
+    <div class="page-wrap">
     {% include navbar.html %}
 
     <div id="masthead-row">
@@ -24,6 +25,7 @@
       <div class="container">
         {{ content }}
       </div>
+    </div>
     </div>
     {% include footer.html %}
   </body>

--- a/_sass/_sticky_footer.scss
+++ b/_sass/_sticky_footer.scss
@@ -1,0 +1,27 @@
+// see https://css-tricks.com/snippets/css/sticky-footer/
+
+html, body {
+  height: 100%;
+  line-height: normal;
+}
+
+.page-wrap {
+  min-height: 100%;
+  margin-bottom: -$footer-height; 
+}
+
+.page-wrap:after {
+  content: "";
+  display: block;
+}
+
+.site-footer, .page-wrap:after {
+  height: $footer-height; 
+}
+
+// override the defaults
+#content-row {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -21,7 +21,7 @@ $grey-color-dark:  darken($grey-color, 20%);
 $on-palm:          600px;
 $on-laptop:        800px;
 
-$footer-height:     130px;
+$footer-height:     70px;
 
 // Use media queries like this:
 // @include media-query($on-palm) {
@@ -38,6 +38,7 @@ $footer-height:     130px;
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
+        "sticky_footer",
         "layout",
         "pagination",
         "sharing",


### PR DESCRIPTION
## The Original Footer

Originally the footer was displayed below the main page content regardless its height. If the content height was small than the screen size the footer was not displayed at the bottom:

![yast_original_footer](https://cloud.githubusercontent.com/assets/907998/21066535/50ad6882-be66-11e6-9336-47e90639aa68.png)

## Fixed Footer

With this fix the footer is always displayed at the bottom, even for a small page content. This looks much better:

![yast_sticky_footer](https://cloud.githubusercontent.com/assets/907998/21066553/7031bbe0-be66-11e6-987d-2f32cb737efe.png)

See https://css-tricks.com/snippets/css/sticky-footer/