### PR TITLE
Update the TW release number

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -135,8 +135,7 @@ See [more details](#debugger_shortcut) in the section above.
 
 #### <a name="debugger_shortcut_systems"></a> Supported Systems
 
-<!-- FIXME: update the version when the yast2-ruby-bindings package is released -->
-- openSUSE Tumbleweed 201611XX or newer
+- openSUSE Tumbleweed 20161117 or newer
 
 ### Using the Integrated Debugger
 


### PR DESCRIPTION
...to the release version which includes the improved debugger.

See the [ML announcement](https://lists.opensuse.org/opensuse-factory/2016-11/msg00410.html) which includes the yast2-ruby-bindings 3.2.1 -> 3.2.2 update.