### PR TITLE
Thumbnail image support

### DIFF
--- a/_includes/blog_img.md
+++ b/_includes/blog_img.md
@@ -1,8 +1,11 @@
 {% capture img_path %}/assets/images/blog/{{ page.date | date: "%Y-%m-%d" }}/{% endcapture %}
 {% if include.ext_link %}
-[![{{ include.alt }}]({{ img_path | append: include.src | relative_url }})]({{ include.ext_link }})
+[![{{ include.alt }}]({{ img_path | append: include.src | relative_url }}){:
+  {{ include.attr }} }]({{ include.ext_link }})
 {% elsif include.full_img %}
-[![{{ include.alt }}]({{ img_path | append: include.src | relative_url }})]({{ img_path | append: include.full_img | relative_url }})
+[![{{ include.alt }}]({{ img_path | append: include.src | relative_url }}){:
+  {{ include.attr }} }]({{ img_path | append: include.full_img | relative_url }})
 {% else %}
-![{{ include.alt }}]({{ img_path | append: include.src | relative_url }})
+![{{ include.alt }}]({{ img_path | append: include.src | relative_url }}){:
+  {{ include.attr }} }
 {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,3 +60,6 @@ layout: default
   </script>
   <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 {% endif %}
+
+<script defer src="{{ "/assets/javascripts/post.js" | relative_url }}"></script>
+

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -87,3 +87,8 @@
   color:red;
   padding-left: 2px;
 }
+
+img.thumbnail {
+  max-width: 300px;
+}
+

--- a/assets/javascripts/post.js
+++ b/assets/javascripts/post.js
@@ -1,0 +1,9 @@
+
+// open the full version of the thumbnail images on click
+$(document).ready(function() {
+  $("img.thumbnail").click(function(){
+    url = $(this).attr("src");
+    window.open(url, "_self");
+  });
+});
+


### PR DESCRIPTION
- Allow passing image attributes in the `blog_img.md` helper (via `attr` parameter)
- CSS style for `.thumbnail` images
- JS code to show the full size on click

Note: the documentation and examples will follow in the next PR.