### PR TITLE
Build and publish a preview at Travis

### DIFF
--- a/.spell.yml
+++ b/.spell.yml
@@ -14,6 +14,8 @@ ignore:
   - 'blog/categories.html'
   - 'blog/tags.html'
   - 'blog/new_post.html'
+  - 'vendor/**/*.html'
+  - 'node_modules/**/*.html'
 dictionary:
 - abovementioned
 - accessor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,27 @@
+
+# no need for sudo, use the container based build for faster boot
+sudo: false
+
 language: ruby
 rvm:
   - 2.1
+
+addons:
+  apt:
+    packages:
+    - libaspell-dev
+    - aspell-en
+    - npm
+
+env:
+  # nokogiri speed up: use the system libxml2, do not compile the bundled version
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+
 before_install:
-  - sudo apt-get update -qq
-  # install aspell headers and the English dictionary
-  - sudo apt-get install --no-install-recommends libaspell-dev aspell-en
+  - npm install surge
+
 script:
   - bundle exec rake
+  - bundle exec jekyll build
+  - bundle exec ./.travis_deploy.rb
+

--- a/.travis_deploy.rb
+++ b/.travis_deploy.rb
@@ -1,0 +1,112 @@
+#! /usr/bin/env ruby
+
+# Publish the page preview at surge.sh using the "surge" tool
+# See https://surge.sh/help/getting-started-with-surge
+# The access tokens are set at https://travis-ci.org/yast/yast.github.io/settings
+# For security reasons this does not work across forks.
+# Additionally it reports the status and the target URL back to GitHub.
+
+require "octokit"
+require "yaml"
+
+# secure variables not present, cannot deploy
+if ENV["TRAVIS_SECURE_ENV_VARS"] != "true"
+  puts "Cannot deploy a preview, required credentials not available!"
+  puts "You still might want to build and publish the preview manually,"
+  puts "see https://surge.sh/help/getting-started-with-surge."
+  exit 0
+end
+
+# create an Octokit client for communication with GitHub
+def client
+  client = Octokit::Client.new(:access_token => ENV["GITHUB_ACCESS_TOKEN"])
+  client.user.login
+  client
+end
+
+def pull_request?
+  ENV["TRAVIS_PULL_REQUEST"] != "false"
+end
+
+# make an unique domain name for the preview, based on the branch name or
+# the pull request number
+def domain
+  return @target_domain if @target_domain
+
+  repo_user = ENV["TRAVIS_REPO_SLUG"].split("/", 2).first
+
+  # use a repo user prefix if this is a fork
+  if repo_user == "yast"
+    repo_user = ""
+  else
+    repo_user << "-"
+  end
+
+
+
+  if pull_request?
+    domain_id = "pull-#{ENV["TRAVIS_PULL_REQUEST"]}"
+  else
+    domain_id = "#{repo_user}branch-#{ENV["TRAVIS_BRANCH"]}"
+  end
+
+  # make a valid domain name
+  domain_id.downcase!
+  domain_id.gsub!(/[^a-z0-9]/, "-")
+  domain_id.gsub!(/\.\//, "-")
+
+  @target_domain = "yast-#{domain_id}.surge.sh"
+end
+
+# full target preview URL
+def url
+  "https://#{domain}"
+end
+
+# set GitHub status
+def set_status(status, description)
+  sha = ENV["TRAVIS_PULL_REQUEST_SHA"]
+  sha = ENV["TRAVIS_COMMIT"] if sha.empty?
+  repo = ENV["TRAVIS_REPO_SLUG"]
+
+  opts = {
+    description: description
+  }
+  opts[:target_url] = url if status == "success"
+  opts[:context] = pull_request? ? "site-preview-pr" : "site-preview"
+
+  puts "Setting GitHub status, repo: #{repo}, sha: #{sha}, status: #{status}"
+
+  client.create_status(repo, sha, status, opts)
+end
+
+# report success at GitHub
+def report_success
+  set_status("success", "Preview available")
+end
+
+# report failure at GitHub and exit
+def report_failure_end_exit
+  set_status("failure", "Preview failed!")
+  exit 1
+end
+
+# update the configuration - change the site URL to the preview target
+def update_config
+  puts "Updating the config, target URL: #{url}"
+  conf_file = "_config.yml"
+  config = YAML.load_file(conf_file)
+  config["url"] = url
+  File.write(conf_file, config.to_yaml)
+end
+
+puts "Rebuilding the pages with the new target URL..."
+update_config
+report_failure_and_exit unless system("bundle exec jekyll build")
+
+puts "Publishing the pages..."
+report_failure_and_exit unless system("`npm bin`/surge --project ./_site --domain #{domain}")
+
+report_success
+puts "\nFinished, see the #{url} page for the site preview."
+

--- a/.travis_deploy.rb
+++ b/.travis_deploy.rb
@@ -19,9 +19,10 @@ end
 
 # create an Octokit client for communication with GitHub
 def client
-  client = Octokit::Client.new(:access_token => ENV["GITHUB_ACCESS_TOKEN"])
-  client.user.login
-  client
+  return @client if @client
+  @client = Octokit::Client.new(:access_token => ENV["GITHUB_ACCESS_TOKEN"])
+  @client.user.login
+  @client
 end
 
 def pull_request?
@@ -31,7 +32,7 @@ end
 # make an unique domain name for the preview, based on the branch name or
 # the pull request number
 def domain
-  return @target_domain if @target_domain
+  return @domain if @domain
 
   repo_user = ENV["TRAVIS_REPO_SLUG"].split("/", 2).first
 
@@ -41,8 +42,6 @@ def domain
   else
     repo_user << "-"
   end
-
-
 
   if pull_request?
     domain_id = "pull-#{ENV["TRAVIS_PULL_REQUEST"]}"
@@ -55,7 +54,7 @@ def domain
   domain_id.gsub!(/[^a-z0-9]/, "-")
   domain_id.gsub!(/\.\//, "-")
 
-  @target_domain = "yast-#{domain_id}.surge.sh"
+  @domain = "yast-#{domain_id}.surge.sh"
 end
 
 # full target preview URL

--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,3 @@ Yast::Tasks.configuration do |conf|
 end
 
 task default: [:"check:spelling"]
-


### PR DESCRIPTION
Travis enhancements:

- Switch to the container based infrastructure (starts faster at Travis)
- Speed up installing the Nokogiri gem: use `libxml2` from the system, avoid compiling the bundled version
- Actually build the pages by Jekyll, check if the build passes
- Build and publish the pages at [surge.sh](https://surge.sh/)
- Report the status and the target URL back to GitHub

Click the commit status icon (the green checkmark) and click the `Details` link for the `site-preview-pr` or check the PR status overview box below, click `Show all checks`.

#### Now you can see a complete page preview even before merging the PR! :tada: 

