### PR TITLE
Footer clean up, added "contacts" page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /_site/
+/_site.txt/
+/node_modules/
 /.bundle/
 /vendor/
 /.vendor/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
-YaST Contribution Guidelines
-============================
+---
+layout: default
+title: YaST Contribution Guidelines
+description: How to Contribute
+---
 
 YaST is an open source project and as such it welcomes all kinds of
 contributions. If you decide to contribute, please follow these guidelines to

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
       <div class="col-sm-12">
         <ul class="list-unstyled">
           <li class="pull-right"><a href="#top">Back to top</a></li>
-          <li><a href="{{ "/contacts" | relative_url }}">Contacts</a></li>
+          <li><a href="{{ "/contact" | relative_url }}">Contact</a></li>
           {% if page.layout == "post" or page.url == "/blog/" %}
           <li><a href="{{ "/blog/new_post" | relative_url }}">New Blog Post</a></li>
           {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,9 +4,7 @@
       <div class="col-sm-12">
         <ul class="list-unstyled">
           <li class="pull-right"><a href="#top">Back to top</a></li>
-          <li><a href="http://build.opensuse.org" target="_blank">Built by OBS</a></li>
-          <li><a href="#">Contact</a></li>
-          <li><a href="#">License</a></li>
+          <li><a href="{{ "/contacts" | relative_url }}">Contacts</a></li>
           {% if page.layout == "post" or page.url == "/blog/" %}
           <li><a href="{{ "/blog/new_post" | relative_url }}">New Blog Post</a></li>
           {% endif %}

--- a/contact.md
+++ b/contact.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Contacts
+title: Contact
 description: Contacting the YaST Team
 ---
 

--- a/contacts.md
+++ b/contacts.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Contacts
+description: Contacting the YaST Team
+---
+
+## How to Contact the YaST Developers
+
+The YaST is as open source project and the developers communicate in an open
+way using mailing lists or IRC.
+
+### The YaST Mailing List
+
+You can contact the YaST team at the [openSUSE `yast-devel` mailing list](
+mailto:yast-devel@opensuse.org).
+
+The [mailing list archive](https://lists.opensuse.org/yast-devel/)
+can be used to look up the older posts.
+
+### The YaST IRC Channel
+
+Use the `#yast` channel at the `freenode.net` server. You can also join via
+the [web interface](http://webchat.freenode.net/?channels=%23yast).
+
+The best time to use IRC is usually between 9-18 hours CET. During weekends
+or public holidays most of the team members are away.
+
+### Reporting Bugs
+
+If you want to report a bug use the [Bugzilla](
+https://bugzilla.suse.com/enter_bug.cgi?format=guided&product=openSUSE+Factory&component=YaST2)
+bug tracking system.
+
+
+## The Other Contacts
+
+- For a generic openSUSE support use the respective [mailing list](
+  https://lists.opensuse.org/) or use the [openSUSE online forums](
+  https://forums.opensuse.org/forum.php). For SUSE Linux Enterprise you can
+  use a paid support.
+
+- For contribution guidelines see the [contributing page](
+  {{ "/contributing" | relative_url }}) or the [CONTRIBUTING.md](
+  {{ "/CONTRIBUTING" | relative_url }}) file in the respective Git repository.
+


### PR DESCRIPTION
Fixes issue #70:

- Removed the `Built by OBS` footer link (IMHO althought we do use OBS we do not need to mention OBS on every page), this makes more space on small (mobile) devices
- Added *Contacts* page and fixed the invalid footer link
- Removed invalid `License` footer link (I do not know the origial intent but it was confusing to me anyway. License of what? The pages? Whole YaST? Or ... ???)
- Render also the CONTRIBUTING.md page

A preview is available at https://yast-pull-89.surge.sh/contacts.