### PR TITLE
Change "predominate" to "predominant"

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -10,7 +10,7 @@ description: Get involved, learn and have a lot of fun!
 
       <h3>1. Meet others involved</h3>
       <p>YaST is a worldwide project with people from many nations and cultures
-      contributing to a common purpose – Making YaST Linux's predominate,
+      contributing to a common purpose – Making YaST Linux's predominant
       all-purpose computing tool. The fastest way to get in contact is
       to simply show up in the <a href="irc://irc.opensuse.org/">#yast</a>
       IRC channel at irc.opensuse.org (freenode). Most YaST developers

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: index
-title: Linux's predominate tool since 1996
+title: Linux's predominant tool since 1996
 description: YaST is the installation and configuration tool for openSUSE and the SUSE Linux Enterprise distributions. It features an easy-to-use interface and powerful configuration capabilities.
 ---
 <div class="row">


### PR DESCRIPTION
Correct the text on the landing page and contributing page to use the
adjective "predominant" rather than the verb "predominate".  Also remove
an extra comma that separated non-coordinate adjectives.