### PR TITLE
A workaround for readthedocs.io to render the exmaples correctly

### DIFF
--- a/doc/localization.md
+++ b/doc/localization.md
@@ -165,11 +165,13 @@ Move the translatable text outside the interpolation so it can be found when
 collecting the translatable strings.
 
 - Use the `+` operator instead of the interpolation
-  ``` ruby
-  "<li>" + _("Item") + "</li>"
-  ```
 - Use a helper variable
-  ``` ruby
-  item = _("Item")
-  "<li>#{item}</li>"
-  ```
+
+##### Examples
+
+``` ruby
+"<li>" + _("Item") + "</li>"
+
+item = _("Item")
+"<li>#{item}</li>"
+```


### PR DESCRIPTION
It seems that readthedocs.io does not render the nested Ruby code correctly, check http://yastgithubio.readthedocs.io/en/latest/localization/#interpolations at the very bottom. :worried: 

Move the examples to a separate block.