### PR TITLE
YaST Team

### DIFF
--- a/doc/yast_team.md
+++ b/doc/yast_team.md
@@ -1,0 +1,14 @@
+# The YaST Team
+
+Here is the list of the core YaST team members. The table contains name mapping
+for several services used  by the team.
+
+<!-- Sort the names by real name (the first name) -->
+
+| Real Name                                 | [IRC][1]       | [Bugzilla][2]          | [GitHub](https://github.com)                    | [Trello](https://trello.com)                            |
+| ----------------------------------------- | -------------- | ---------------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| Ladislav Slezák                           | lslezak        | lslezak@suse.com       | [lslezak](https://github.com/lslezak/)          | [ladislavslezak](https://trello.com/ladislavslezak)     |
+
+
+[1]: https://webchat.freenode.net/?channels=%23yast
+[2]: https://bugzilla.suse.com

--- a/doc/yast_team.md
+++ b/doc/yast_team.md
@@ -1,14 +1,4 @@
 # The YaST Team
 
-Here is the list of the core YaST team members. The table contains name mapping
-for several services used  by the team.
-
-<!-- Sort the names by real name (the first name) -->
-
-| Real Name                                 | [IRC][1]       | [Bugzilla][2]          | [GitHub](https://github.com)                    | [Trello](https://trello.com)                            |
-| ----------------------------------------- | -------------- | ---------------------- | ----------------------------------------------- | ------------------------------------------------------- |
-| Ladislav Slezák                           | lslezak        | lslezak@suse.com       | [lslezak](https://github.com/lslezak/)          | [ladislavslezak](https://trello.com/ladislavslezak)     |
-
-
-[1]: https://webchat.freenode.net/?channels=%23yast
-[2]: https://bugzilla.suse.com
+See [this wiki page](https://github.com/yast/yast.github.io/wiki/The-YaST-Team)
+for the details about the core YaST team.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,3 @@
 site_name: Yast Documentation
 docs_dir: doc
+theme: readthedocs


### PR DESCRIPTION
# The Team

- As discussed on the daily call, let's have some table with the team member (nick)names.
- The long lines in the table do not look nice in the GitHub diff but in an editor that should be OK.
- The additional commit switches to the same theme as the online [readthedocs.io](https://readthedocs.io) service, you can see the same preview when rendering the pages locally

## Preview

When rendered locally:

![yast_team](https://user-images.githubusercontent.com/907998/32550654-3d1263ac-c48e-11e7-92cc-75aba72d9e26.png)


## Questions to Discuss

- Do we need a separate `Email` column? I guess the Bugzilla email should work anyway so we do not need yet another (possibly duplicated) column.
- If we do not want to expose the email address in the Bugzilla column we could use the Bugzilla name there a well. Bugzilla has a name completion feature.
- How should we sort the names in the table? Is the first name OK?
- I was thinking about to add an `Expert area` column (or something like that) where we could write the knowledge and the areas which we are responsible for. That could help when you need to ask someone.
   - Would that make sense?
   - But that would not fit the display area, it is quite narrow (see the screenshot above). I'd avoid scrolling, it is annoying. We would probably need a separate table below this one.


