### PR TITLE
added note about translations

### DIFF
--- a/doc/branching-how-to.md
+++ b/doc/branching-how-to.md
@@ -151,3 +151,8 @@ exceptions which need a special care:
   in the [control.leanos.xml](
   https://github.com/yast/skelcd-control-leanos/blob/master/control/control.leanos.xml) file. Also check
   whether the `<full_system_download_url>` value is correct.
+
+## Translations
+
+For new branches where translations are required the SUSE Localization
+Team has to be informed.


### PR DESCRIPTION
I was informed by a colleague that the translation team must be informed about new branches, in this case for libstorage-ng. This information must be documented so that anyone who does new branches can do the right thing.
