### PR TITLE
Always show the "Blog" link in the page header

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -22,12 +22,9 @@
         <li class="{% if page.url == "/guidelines.html" %}active{% endif %}">
           <a href="{{ "/guidelines" | relative_url }}">Guidelines</a>
         </li>
-        <!-- FIXME: temporarily disabled, enable when the blog is fully working -->
-        {% if page.url == "/blog/" %}
         <li class="{% if page.url == "/blog/" %}active{% endif %}">
           <a href="{{ "/blog" | relative_url }}">Blog</a>
         </li>
-        {% endif %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
- As discussed on the retrospective meeting, let's enable the "Blog" link at the page header so people get to know it.