### PR TITLE
Disable the font ligatures for the "Doppio One" font

### DIFF
--- a/_sass/custom/_header.scss
+++ b/_sass/custom/_header.scss
@@ -16,6 +16,7 @@
 
 .navbar-brand {
   font-family: "Doppio One";
+  font-variant-ligatures: none;
   font-size: 24px;
   line-height: 21px;
   padding: 20px 15px 20px;

--- a/_sass/custom/_layout.scss
+++ b/_sass/custom/_layout.scss
@@ -9,6 +9,7 @@
 
 h1, h2, h3 {
   font-family: "Doppio One" ;
+  font-variant-ligatures: none;
 }
 
 h3 .glyphicon {


### PR DESCRIPTION
- They look ugly and might be completely broken in some browsers...

## Screenshots

#### Original

![css_original](https://user-images.githubusercontent.com/907998/74016296-7bd79400-4992-11ea-9f70-67a38b8a3fb2.png)

#### Fixed 

![css_no_ligatures](https://user-images.githubusercontent.com/907998/74016334-88f48300-4992-11ea-8e47-c76be5e8b80a.png)
