### PR TITLE
Set correct permalinks for crosslinking

### DIFF
--- a/.spell.yml
+++ b/.spell.yml
@@ -243,6 +243,7 @@ dictionary:
 - PARSECOMMENTS
 - partitioner
 - perl
+- permalink
 - plugin
 - png
 - pos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /CONTRIBUTING/
 title: YaST Contribution Guidelines
 description: How to Contribute
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,5 @@ exclude:
   - README.md
   - sass_debug
   - vendor
+  - Rakefile
+  - mkdocs.yml

--- a/blog/categories.html
+++ b/blog/categories.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /blog/categories/
 title: Blog Post Categories
 description: Find Blog Posts by a Category
 ---

--- a/blog/how_to_write.md
+++ b/blog/how_to_write.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /blog/how_to_write/
 title: "How to Write a New Post"
 description: "A short introduction about writing new blog posts"
 sitemap: false

--- a/blog/new_post.html
+++ b/blog/new_post.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /blog/new_post/
 title: New Blog Post
 description: Create template for a new blog post
 sitemap: false

--- a/blog/tags.html
+++ b/blog/tags.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /blog/tags/
 title: Blog Post Tags
 description: Find Blog Posts by a Tag
 ---

--- a/contact.md
+++ b/contact.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /contact/
 title: Contact
 description: Contacting the YaST Team
 ---

--- a/contributing.html
+++ b/contributing.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /contributing/
 title: Contributing
 description: Get involved, learn and have a lot of fun!
 ---

--- a/documentation.html
+++ b/documentation.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /documentation/
 title: Documentation
 description: Discover YaST development
 ---

--- a/guidelines.html
+++ b/guidelines.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /guidelines/
 title: Guidelines
 description: How we collaborate
 ---

--- a/modules.html
+++ b/modules.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /modules/
 title: Modules
 description: Extending the functionality of YaST across a variety of modules.
 


### PR DESCRIPTION
Allows to link to `/path/` and not `path.html` in a host independent way