### PR TITLE
Remove the bundler version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,3 @@ DEPENDENCIES
   rake
   raspell
   yast-rake (>= 0.2.1)
-
-BUNDLED WITH
-   2.0.2


### PR DESCRIPTION
- Travis failed: https://ci.opensuse.org/view/Yast/job/yast-yast.github.io-master/81/console
- Because of this recent change: https://github.com/yast/yast.github.io/pull/225/files#diff-e79a60dc6b85309ae70a6ea8261eaf95R258-R260
- It seems that Jenkins runs some older Ruby (openSUSE Leap) version...