### PR TITLE
Set the yast.opensuse.org as the default address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: YaST
 description: powerful installation and configuration tool for Linux
 email: yast-devel@opensuse.org
 baseurl: ""
-url: "https://yast.github.io"
+url: "https://yast.opensuse.org"
 
 defaults:
   -


### PR DESCRIPTION
Makes it so the rss feed links to the site