### PR TITLE
Fixed link to the journalctl tutorial

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -17,7 +17,7 @@ description: Discover YaST development
       development, it's crucial to understand what is the role of every component,
       how they relate to each other and where they live in the GitHub
       infrastructure. That is explained in the
-      <a href="http://yastgithubio.readthedocs.org/en/latest/architecture/">YaST
+      <a href="https://yastgithubio.readthedocs.org/en/latest/architecture/">YaST
       architecture</a> document.
       </p>
 
@@ -25,7 +25,7 @@ description: Discover YaST development
       That complex system is translated into files and folders in a consistent way all
       along the full set of YaST repositories and therefore in the
       installed system, as detailed in the
-      <a href="http://en.opensuse.org/openSUSE:YaST:_Code_Organization">YaST code
+      <a href="https://en.opensuse.org/openSUSE:YaST:_Code_Organization">YaST code
       organization description</a>.
       </p>
 
@@ -34,7 +34,7 @@ description: Discover YaST development
       The core system of YaST is implemented using a mixture of languages, but the
       whole functionality is easily accessible from Ruby, the language used to
       implement almost all modules. The
-      <a href="http://rubydoc.info/github/yast/yast-ruby-bindings/">documentation
+      <a href="https://rubydoc.info/github/yast/yast-ruby-bindings/">documentation
       of YaST Ruby bindings</a> contains comprehensive information not only about
       the way to access SCR or WFM from Ruby, but also about the legacy modes used
       during the transition from the YCP language to Ruby, like Ops or Builtins.
@@ -46,7 +46,7 @@ description: Discover YaST development
       Linux system configuration, from network to packages management and from
       hardware status to systemd. YaST basic libraries provide access to that
       API and to several YaST specific mechanisms and concepts. Full documentation can
-      be found on the <a href="http://rubydoc.info/github/yast/yast-yast2/">yast-yast2 page
+      be found on the <a href="https://rubydoc.info/github/yast/yast-yast2/">yast-yast2 page
       on Rubydoc</a>.
       </p>
 
@@ -71,13 +71,13 @@ description: Discover YaST development
 
       <p>
       Even if libYUI is used through the very convenient wrappers, the
-      <a href="http://doc.opensuse.org/projects/YaST/openSUSE11.3/tdg/Book-UIReference.html">UI
+      <a href="https://doc.opensuse.org/projects/YaST/openSUSE11.3/tdg/Book-UIReference.html">UI
       reference documentation</a> and the
-      <a href="http://doc.opensuse.org/projects/YaST/openSUSE11.3/tdg/Book-YCPUIlayout.html">UI
+      <a href="https://doc.opensuse.org/projects/YaST/openSUSE11.3/tdg/Book-YCPUIlayout.html">UI
       layouts and events guide</a> from the original C++ API are still the best
       sources of information to know how every class and method works under the hood.
       Currently there is also new experimental on the fly generated documentation for this
-      <a href="http://yast-ui-bindings.surge.sh/">API</a>.
+      <a href="https://yast-ui-bindings.surge.sh/">API</a>.
       </p>
 
       <h3>The installation process</h3>
@@ -88,7 +88,7 @@ description: Discover YaST development
       during the installation process, from Linuxrc to the final steps of
       installation, including configuration proposals or partitioner, it's highly
       recommended to read the
-      <a href="http://rubydoc.info/github/yast/yast-installation/">documentation of the
+      <a href="https://rubydoc.info/github/yast/yast-installation/">documentation of the
       yast-installation module</a>.
       </p>
 
@@ -96,7 +96,9 @@ description: Discover YaST development
       <p>
       Those willing to take their first steps into YaST development can follow
       the tutorial titled
-      &quot;<a href="http://yast.github.io/yast-journalctl-tutorial/">creating
+      <!-- the yast.github.io URL does not work, it's redirected to yast.opensuse.org
+      which does not contain the pages, as a workaround we use a fork here -->
+      &quot;<a href="https://ancorgs.github.io/yast-journalctl-tutorial/">creating
       the YaST journalctl module</a>&quot;. The document, targeted to developers
       with no prior experience with YaST, presents a very simple example of a
       YaST module developed from scratch and provides a good overview of the
@@ -115,7 +117,7 @@ description: Discover YaST development
       <p>
       In addition to those tricks, you can find several bits of useful information in
       the
-      <a href="http://yastgithubio.readthedocs.org/en/latest/development-tips/">YaST
+      <a href="https://yastgithubio.readthedocs.org/en/latest/development-tips/">YaST
       development tips and tricks</a> document.
       </p>
     </div>


### PR DESCRIPTION
- Fixes https://github.com/yast/yast-journalctl-tutorial/issues/10
- Additionally the URLs have been switched to more secure `https` scheme