### PR TITLE
Fix link to YaST tutorial

### DIFF
--- a/_posts/2017-03-07-yast-development-during-hack-week-15.md
+++ b/_posts/2017-03-07-yast-development-during-hack-week-15.md
@@ -150,7 +150,7 @@ Stay tunned!
 
 
 [1]: https://letsencrypt.org/
-[2]: http://yast.github.io/yast-journalctl-tutorial/
+[2]: https://ancorgs.github.io/yast-journalctl-tutorial/
 [3]: https://daniel.molkentin.net/2017/02/28/letsencrypt-support-for-opensuse/
 [4]: https://hackweek.suse.com/projects/get-rid-of-perl-apparmor
 [5]: https://github.com/goldwynr/yast-apparmor

--- a/doc/yast_is_open.md
+++ b/doc/yast_is_open.md
@@ -28,7 +28,7 @@ actually YaST offer to the community? Here is the summary:
   ([#yast at irc.freenode.org](https://webchat.freenode.net/?channels=%23yast)).
 
 - [The developer's documentation](http://yastgithubio.readthedocs.org/en/latest/)
-  and a [tutorial](http://yast.github.io/yast-journalctl-tutorial/) describing
+  and a [tutorial](https://ancorgs.github.io/yast-journalctl-tutorial/) describing
   step-by-step how to create a new YaST module from scratch for easy start with
   YaST development.
 


### PR DESCRIPTION
Replacing https://yast.opensuse.org/yast-journalctl-tutorial by https://ancorgs.github.io/yast-journalctl-tutorial/ because the former  leads to an internal server error.

