### PR TITLE
Update versioning documentation

### DIFF
--- a/doc/versioning.md
+++ b/doc/versioning.md
@@ -13,61 +13,56 @@ From now on, version numbers will be tied to the SUSE versions:
 
 * Major number is related to the major SUSE version (4 for SLE 15, 5 for
   SLE 16, and so on).
-* Minor number is related to the SUSE Service Pack number (0, 1, 2...).
+* Minor number is related to the SUSE Service Pack number (0 for SP0, 1 for SP1, etc).
 * Patch number enumerates versions for a given major/minor version.
 
-For instance, `4.2.3` would be the fourth version of the package for SLE 15 SP2
+For instance, *4.2.3* would be the fourth version of the package for SLE 15 SP2
 (the first one would be 4.2.0).
 
 ### When to bump each number
 
+YaST repositories keep a git branch for every released (open)SUSE product. For example, a
+*SLE-15-SP1* branch is used for the development of *SLE 15 SP1* and *openSUSE Leap 15.1* products,
+*SLE-15-SP2* for *SLE 15 SP2* and *openSUSE Leap 15.2*, etc. The *master* branch is used for
+*Factory* and also for the service pack (or major release) that is currently in development phase.
+As described above, each YaST version corresponds to a specific product. So, when a change is
+introduced in a branch, the next version would be defined by the product that branch is tracking.
+For example, the first change in the *SLE-15-SP2* branch would have the version *4.2.0*.
+
 Basically, these are the rules for increasing version numbers:
 
-* The first commit that introduces a divergence which is meant to be only
-  available in the next major SUSE release should increment the *major*
-  version (e.g., from `4.3.45` to `5.0.0`).
-* The first commit that introduces a divergence which is meant to be only
-  available in the next Service Pack release should increment the *minor*
-  version (e.g., from `4.3.45` to `4.4.0`).
-* Every fix/change that goes as a *maintenance update* should increment the
-  *patch* number (`4.0.1`, `4.0.2`, etc.).
-
-Note that during the development phase of the next product (either a Service Pack or a major release),
-only the *patch* number is bumped meanwhile there is no code divergence regarding the previous product.
-The *major* and *minor* numbers are properly bumped before the product release in case no divergence has
-been introduced during the development phase.
+* The first commit to a branch will use the version for the tracked product, with *patch* number *0*
+  (e.g., *4.3.0* for *SLE-15-SP3*, *5.0.0* for *SLE-16-GA*, etc).
+* Next changes in a branch will increment the *patch* number (*4.3.1*, *4.3.2*, etc.).
 
 ### Example
 
-Let's try an example for a better understading about how the new YaST versioning policy works.
+Let's try an example for a better understanding about how the new YaST versioning policy works.
 
-Scenario: last realesed product was SLE 15 (SP0) and SLE 15 SP1 is currently on its development
-phase. Moreover, there is a package `yast2-example` which version is `4.0.9` and there is a
-`SLE-15-GA` branch in the repository.
+Scenario: last released product was *SLE 15 SP0* (a.k.a. *SLE 15 GA*) and *SLE 15 SP1* is starting
+its development phase. Moreover, there is a package *yast2-example* which version is *4.0.9*.
+A *SLE-15-GA* branch was created after releasing *SLE 15 SP0*.
 
-### Fix a bug for the latest released Service Pack: SLE 15 SP0
+### Fix a bug for the latest released Service Pack: *SLE 15 SP0*
 
-1. The fix is implemented into the `SLE-15-GA` branch and the *patch* number is increased from
-   `4.0.9` to `4.0.10`.
-2. Then the fix is merged into master (to also include it as part of SP1). If there is no
-   code divergence yet with master branch, then the version is kept as `4.0.10` in master too.
-   But if some changes were included into master previously (e.g., for the implementation
-   of a new feature for SP1, see next example), the version number in master would be bumped from
-   something like `4.1.3` to `4.1.4`.
+1. The fix is implemented into the *SLE-15-GA* branch and the *patch* number is increased from
+   *4.0.9* to *4.0.10*.
+2. Then the fix is merged into master in order to also include it as part of SP1. In this case, the
+   version for *master* would be *4.1.X* because *master* is now tracking the development of
+   *SLE 15 SP1* (and *Factory*). Note that the *patch* number will be *0* or the next corresponding
+   number if *master* already contains a *4.1.X* version.
 
-### Add new a change for the next Service Pack: SLE 15 SP1
+### Add new a change for the next Service Pack: *SLE 15 SP1*
 
-1. The feature/fix is implemented into the master branch.
-2. If this is the first divergence with the `SLE-15-GA` branch, the *minor* number is increased
-   from `4.0.9` to `4.1.0`. Otherwise, only the *patch* number is increased, e.g., from
-   `4.1.3` to `4.1.4`.
+1. The feature/fix is implemented into the *master* branch.
+2. Again, the version would be *4.1.X* because *master* is tracking the development of *SLE 15 SP1*
+   (and *Factory*).
 
-### Add a new change for the next SLE major version: SLE 16 SP0
+### Add a new change for the next SLE major version: *SLE 16 SP0*
 
-1. The feature/fix is implemented into the master branch.
-2. If this is the first divergence with the previous product, the *major* number is increased
-   from `4.0.9` to `5.0.0`. Otherwise, only the *patch* number is increased, e.g., from
-   `5.0.3` to `5.0.4`.
+1. The feature/fix is implemented into the *master* branch.
+2. And the version in this case would be *5.0.X* (the *major* number for *SLE 16* is *5* and the
+  *minor* number for *SP0* is *0*).
 
 
 ## Old schema

--- a/doc/versioning.md
+++ b/doc/versioning.md
@@ -11,13 +11,13 @@ openSUSE Leap 42.x, have a look at the *Old schema* section of this document.
 
 From now on, version numbers will be tied to the SUSE versions:
 
-* Major number is related to the major SUSE version (4 for SLE 15, 5 for
-  SLE 16, and so on).
-* Minor number is related to the SUSE Service Pack number (0 for SP0, 1 for SP1, etc).
+* Major number is related to the major SUSE version (*4* for *SLE 15*, *5* for
+  *SLE 16*, and so on).
+* Minor number is related to the SUSE Service Pack number (*0* for *SP0*, *1* for *SP1*, etc).
 * Patch number enumerates versions for a given major/minor version.
 
-For instance, *4.2.3* would be the fourth version of the package for SLE 15 SP2
-(the first one would be 4.2.0).
+For instance, *4.2.3* would be the fourth version of the package for *SLE 15 SP2*
+(the first one would be *4.2.0*).
 
 ### When to bump each number
 
@@ -37,17 +37,17 @@ Basically, these are the rules for increasing version numbers:
 
 ### Example
 
-Let's try an example for a better understanding about how the new YaST versioning policy works.
+Let's try an example to illustrate how the new YaST versioning policy works.
 
 Scenario: last released product was *SLE 15 SP0* (a.k.a. *SLE 15 GA*) and *SLE 15 SP1* is starting
-its development phase. Moreover, there is a package *yast2-example* which version is *4.0.9*.
+its development phase. Moreover, there is a package *yast2-example* with version *4.0.9*.
 A *SLE-15-GA* branch was created after releasing *SLE 15 SP0*.
 
 ### Fix a bug for the latest released Service Pack: *SLE 15 SP0*
 
 1. The fix is implemented into the *SLE-15-GA* branch and the *patch* number is increased from
    *4.0.9* to *4.0.10*.
-2. Then the fix is merged into master in order to also include it as part of SP1. In this case, the
+2. Then the fix is merged into *master* in order to also include it as part of SP1. In this case, the
    version for *master* would be *4.1.X* because *master* is now tracking the development of
    *SLE 15 SP1* (and *Factory*). Note that the *patch* number will be *0* or the next corresponding
    number if *master* already contains a *4.1.X* version.


### PR DESCRIPTION
The documentation about the new version schema was not clear about how/when to bump the version.
