### PR TITLE
Repaired links

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@ YaST documentation
 YaST is the installation and configuration tool for openSUSE and the SUSE Linux
 Enterprise distributions.
 
-The YaST landing page located at [http://yast.github.io](http://yast.github.io)
+The YaST landing page located at [https://yast.opensuse.org/](https://yast.opensuse.org/)
 provides a clear view of the whole project for both users and developers, but
 with a stronger focus in the latter.
 
@@ -14,6 +14,6 @@ corresponding development documentation. In addition to that specific
 documentation, this directory contains some documents targeted to developers and
 related to the project as a whole. All the documentation is referenced from the
 already mentioned YaST landing page at
-[http://yast.github.io/](http://yast.github.io), which aggregates
+[https://yast.opensuse.org/](https://yast.opensuse.org/), which aggregates
 links to several sources of information (including the different files in this
 directory) in a way that makes sense and is easy to digest for newcomers.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -5,7 +5,7 @@ view on how the YaST world is structured. The goal of this document is to
 provide that view in a concise way, mentioning all the pieces and exposing how
 they fit together. For a more detailed view about any of the technologies or
 components, refer to the corresponding documentation linked from the central
-documentation page for YaST at [http://yast.github.io](http://yast.github.io).
+documentation page for YaST at [https://yast.opensuse.org/](https://yast.opensuse.org/).
 
 ## Overview
 
@@ -158,4 +158,4 @@ The goal of this document is just to provide a high level view of the YaST
 development ecosystem. More detailed documentation about the involved
 technologies, tools and procedures can always be found in the central
 documentation page for YaST, available at
-[http://yast.github.io](http://yast.github.io).
+[https://yast.opensuse.org/](https://yast.opensuse.org/).

--- a/doc/building-the-doc-locally.md
+++ b/doc/building-the-doc-locally.md
@@ -1,7 +1,7 @@
 # Building this Documentation Locally
 
 This documentation is also built at
-[http://yastgithubio.readthedocs.org](http://yastgithubio.readthedocs.org) server.
+[http://yastgithubio.readthedocs.org](https://yastgithubio.readthedocs.org) server.
 
 The problem is that Markdown rendering is not standardized and each renderer
 can produce a slightly different output. That means the HTML version might be displayed

--- a/doc/ci-integration.md
+++ b/doc/ci-integration.md
@@ -147,7 +147,7 @@ packages.
 - First make sure the Docker is installed and running, which usually means to run
   `zypper in docker` and `systemctl start docker`. For SUSE Linux Enterprise
   you can check the [official Docker documentation](
-  https://docs.docker.com/engine/installation/linux/suse/).
+  https://docs.docker.com/engine/install/sles/).
 
 - Then use the [`rake actions:run`](https://github.com/yast/yast-rake#actionsrunjob)
   Rake task.

--- a/doc/code-review.md
+++ b/doc/code-review.md
@@ -4,7 +4,7 @@ First of all, thank you for contributing to YaST! Anyway, there are some rules
 that anyone needs to follow while doing so...
 
 Every single change in code (including bug fix, new feature, etc.) needs to go
-through a code [review](http://en.wikipedia.org/wiki/Code_review) using
+through a code [review](https://en.wikipedia.org/wiki/Code_review) using
 a [Pull Request](https://help.github.com/articles/using-pull-requests).
 
 *Note: The security issues need be to handled a bit differently, see [how to handle
@@ -62,7 +62,7 @@ on the code robustness.
 * All tests have to be green (`rake osc:build` before submitting)
 * No Builtins.* or Ops.* unless really necessary in new code
 * Function documentation (function description, arguments, return values)
-* Following the [Ruby style guide](https://github.com/SUSE/style-guides/blob/master/Ruby.md)
+* Following the [Ruby style guide](https://github.com/SUSE/scc-codestyle)
 * Understandable variable names
 * Good test quality
 * Build has to be green (`rake osc:build` before submitting)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -17,12 +17,10 @@ documentation, the security related bugs need a special handling.*
 
 If you find a problem, please report it either using
 [Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?format=guided&product=openSUSE+Tumbleweed&component=YaST2)
-or [GitHub issues](../../issues). (For Bugzilla, use the [simplified
-registration](https://secure-www.novell.com/selfreg/jsp/createSimpleAccount.jsp)
-if you don't have an account yet.)
+or GitHub issues (in the respective repository).
 
 When creating a bug report, please follow our [bug reporting
-guidelines](http://en.opensuse.org/openSUSE:Report_a_YaST_bug).
+guidelines](https://en.opensuse.org/openSUSE:Report_a_YaST_bug).
 
 We can't guarantee that every bug will be fixed, but we'll try.
 
@@ -48,7 +46,7 @@ follows:
 
   3. Implement your change, including tests (if possible). Make sure you adhere
      to the [Ruby style
-     guide](https://github.com/SUSE/style-guides/blob/master/Ruby.md).
+     guide](https://github.com/SUSE/scc-codestyle).
 
   4. Update the package version (in `packages/*.spec`, usually by
      `rake version:bump`) and add a new entry to the `package/*.changes` file
@@ -92,6 +90,6 @@ Additional Information
 ----------------------
 
 If you have any question, feel free to ask at the [development mailing
-list](http://lists.opensuse.org/yast-devel/) or at the
+list](https://lists.opensuse.org/archives/list/yast-devel@lists.opensuse.org/) or at the
 [#yast](https://web.libera.chat/#yast) IRC channel.
 We'll do our best to provide a timely and accurate answer.

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -18,9 +18,9 @@ sudo zypper in 'rubygem(byebug)'
 ```
 
 If the package is not available in your repositories you can install it from
-[YaST:Head]( http://download.opensuse.org/repositories/YaST:/Head/) or
+[YaST:Head](https://download.opensuse.org/repositories/YaST:/Head/) or
 [devel:languages:ruby:extensions](
-http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/)
+https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/)
 repositories.
 
 ## Starting the Debugger in Installed System

--- a/doc/development-tips.md
+++ b/doc/development-tips.md
@@ -31,12 +31,12 @@ Driver updates are a mechanism that allows to modify the system before starting
 the installation by providing a set of rpm packages. A driver update can be
 triggered by the ```dud``` option in the Linuxrc command line. More information
 about this approach can be found in the
-[corresponding section](http://en.opensuse.org/Linuxrc#p_driverupdate) of
+[corresponding section](https://en.opensuse.org/Linuxrc#p_driverupdate) of
 the Linuxrc documentation.
 
 When using this method with many RPM packages, it's usually convenient to use a
 [Linuxrc control
-file](http://doc.opensuse.org/projects/autoyast/appendix.linuxrc.html)
+file](https://doc.opensuse.org/projects/autoyast/#ay-cmd-parameters)
 containing ```insecure=1``` and several ```dud``` options.
 
 ### Using a YaST update medium
@@ -46,7 +46,7 @@ also triggered by the ```dud``` Linuxrc option and they also
 allow to modify the system before the installation, but they only affect the
 files located under ```/usr/share/YaST2```. More information can be found
 in the [corresponding
-section](http://ftp.sunet.se/pub/Linux/distributions/suse/people/hvogel/Update-Media-HOWTO/html/id_yud.html)
+section](ftp://ftp.suse.de/pub/people/hvogel/Update-Media-HOWTO/html/id_yud.html)
 of the Update Media HOWTO.
 
 ### Running a shell before the installation
@@ -57,7 +57,7 @@ itself. In this way it's not only possible to modify any YaST file in advance
 but also to configure the network or any other aspect of the system. More
 information can be found in
 [this Kobliha's blog
-post](http://kobliha-suse.blogspot.cz/2009/10/easiest-way-how-to-modify-installation.html).
+post](https://kobliha-suse.blogspot.cz/2009/10/easiest-way-how-to-modify-installation.html).
 
 ## Add a new package to the installation system
 
@@ -77,4 +77,4 @@ systems, already released product or the rescue image then you need to modify
 the ```installation-images``` package and then remaster the installation medium
 (or update the boot server, depending how you boot the system). But there are
 some tricky parts that are explained in depth in [this Ladislav's blog
-post](http://lslezak.blogspot.cz/2013/10/adding-new-package-to-opensuse.html).
+post](https://lslezak.blogspot.cz/2013/10/adding-new-package-to-opensuse.html).

--- a/doc/development.md
+++ b/doc/development.md
@@ -5,8 +5,9 @@ YaST Development Documentation
 Documentation Links
 -------------------
 
-- [YaST development documentation](http://yast.github.io/documentation.html)
-- [Contribution Guidelines](http://yast.github.io/guidelines.html)
+- [YaST development overview](https://yast.opensuse.org/documentation)
+- [YaST development documentation](development.md)
+- [Contribution Guidelines](contributing.md)
 - [YaST architecture](architecture.md)
 
 
@@ -34,7 +35,7 @@ To prepare the development environment in Factory or Tumbleweed, install the
 To prepare the development environment in openSUSE, build and install the
 `yast2-devtools` package yourself from the current source code (the
 version present in the last openSUSE release might be too old).
-You may need to install the [development dependencies](Development-Dependencies) first.
+You may need to install the [development dependencies](#development-dependencies) first.
 
 Then, to compile _yast devtools_ from source code, execute these commands:
 
@@ -61,7 +62,7 @@ available from outside.
 
 * Creating new repository under the [yast](https://github.com/yast/) path
   at GitHub
-* Adjusting [RuboCop rules](http://lslezak.blogspot.cz/2014/11/using-rubocop.html)
+* Adjusting [RuboCop rules](https://lslezak.blogspot.cz/2014/11/using-rubocop.html)
 * Creating the package in OBS at [YaST:Head](https://build.opensuse.org/project/show/YaST:Head)
   project and in IBS at [Devel:YaST:Head](https://build.suse.de/project/show/Devel:YaST:Head)
   project (if you plan to have it in SLE)

--- a/doc/how-to-write-tests.md
+++ b/doc/how-to-write-tests.md
@@ -122,9 +122,8 @@ must be explicitly included in `yast2_cmdline.pm`.
 # Links
 
 * RSpec
-  * [Better Specs](http://betterspecs.org/) - rspec guidelines with Ruby
+  * [Better Specs](https://betterspecs.org/) - rspec guidelines with Ruby
   * [The RSpec Style Guide](https://github.com/reachlocal/rspec-style-guide)
-  * [YaST RSpec helpers](http://www.rubydoc.info/github/yast/yast-ruby-bindings#Testing)
-* openQA
-  * [openQA landing page](http://os-autoinst.github.io/openQA/)
-  * [yast-modules branch of the opensuse distri](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/yast-modules)
+  * [YaST RSpec helpers](https://github.com/yast/yast-ruby-bindings#testing)
+  * [openQA](https://open.qa/)
+  * [yast-modules branch of the opensuse distri](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/yast2_cmd)

--- a/doc/localization.md
+++ b/doc/localization.md
@@ -71,7 +71,7 @@ n_("one package from %{repo}", "%{size} packages from %{repo}", packages.size) %
 ```
 
 See the [GNU gettext manual](
-http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Plural-forms.html)
+https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Plural-forms.html)
 for more details about plural forms.
 
 ## Using Named Parameters

--- a/doc/maintenance-branches.md
+++ b/doc/maintenance-branches.md
@@ -25,7 +25,7 @@ The following rules apply to working with maintenance branches:
   changes the SHA because the commit will get a new parent commit. And with
   different SHAs, it is difficult to find out if all desired commits from the
   branch are now also in master. For deeper explanation see these articles
-  [1](http://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](http://www.draconianoverlord.com/2013/09/07/no-cherry-picking.html) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
+  [1](https://dan.bravender.net/2011/10/20/Why_cherry-picking_should_not_be_part_of_a_normal_git_workflow.html), [2](https://www.draconianoverlord.com/2013/09/07/if-you-cherry-pick-your-branch-model-is-wrong.html/) or [reddit](https://www.reddit.com/r/git/comments/3ubuel/merge_vs_rebase_why_not_cherrypick/))
 * merge new maintenance branches to master regularly
 * create fix for the oldest applicable branch first
 

--- a/doc/security-tips.md
+++ b/doc/security-tips.md
@@ -157,7 +157,7 @@ problematic.
   ) module or the [cheetah](https://github.com/openSUSE/cheetah) gem directly
   for running external commands
 - Use the [Shellwords.escape](
-  http://ruby-doc.org/stdlib-2.2.0/libdoc/shellwords/rdoc/Shellwords.html)
+  https://ruby-doc.org/stdlib-2.2.0/libdoc/shellwords/rdoc/Shellwords.html)
   Ruby method, e.g. `/bin/rpm -q #{Shellwords.escape(user_input)}`
 - Use the absolute path, e.g. `/bin/rpm`
   *Note: The very old YaST approach was NOT using the absolute path. This has
@@ -354,7 +354,7 @@ they are disabled by default.
   on request. And if possible, by default allow only local access via the
   loopback device (`localhost`/`127.0.0.1`).
 
-See more details in the [debugging](./debugging) document about the integrated
+See more details in the [debugging](debugging.md) document about the integrated
 Ruby debugger support in YaST.
 
 

--- a/doc/yast_is_open.md
+++ b/doc/yast_is_open.md
@@ -10,7 +10,7 @@ actually YaST offer to the community? Here is the summary:
 - [The YaST portal](https://en.opensuse.org/Portal:YaST) at openSUSE Wiki - the
   perfect starting point for users, with lots of information and documentation.
 
-- [The YaST home page](http://yast.github.io/) - the starting point for YaST
+- [The YaST home page](https://yast.opensuse.org/) - the starting point for YaST
   developers and contributors.
 
 - Open development - the source code repositories are hosted at
@@ -24,20 +24,19 @@ actually YaST offer to the community? Here is the summary:
 
 - Open communication - we have a public mailing list
   (yast-devel(at)opensuse.org, with on-line
-  [archive](http://lists.opensuse.org/yast-devel)), we use a public IRC channel
+  [archive](https://lists.opensuse.org/archives/list/yast-devel@lists.opensuse.org/)), we use a public IRC channel
   ([#yast at irc.libera.chat](https://web.libera.chat/#yast)).
 
-- [The developer's documentation](http://yastgithubio.readthedocs.org/en/latest/)
+- [The developer's documentation](https://yastgithubio.readthedocs.org/en/latest/)
   and a [tutorial](https://ancorgs.github.io/yast-journalctl-tutorial/) describing
   step-by-step how to create a new YaST module from scratch for easy start with
   YaST development.
 
-- Open [bug](https://bugzilla.suse.com) and
-  [feature](https://fate.opensuse.org) tracking for reporting errors and
+- Open [bug](https://bugzilla.suse.com) tracking for reporting errors and
   suggesting improvements.
 
 - Public [Continuous Integration service](https://ci.opensuse.org/view/Yast/)
-  (a [Jenkins](http://jenkins-ci.org/) instance) for testing the latest code.
+  (a [Jenkins](https://jenkins-ci.org/) instance) for testing the latest code.
 
 - The latest bleeding edge YaST RPM packages built from Git sources are
   available in [YaST:Head](https://build.opensuse.org/project/show/YaST:Head)


### PR DESCRIPTION
Hi!

Thanks for the great documentation  - it is really helpful!
Browsing through it, I found some dead links. I replaced those with working substitutes, and used the opportunity to also replace http links with https ones, and redirecting links with their respective targets.

There are two instances I am not completely confident as to whether my substitution is correct, as I could only locate a matching repository, but not the exact file:
https://github.com/tacerus/yast.github.io/blob/00b19abf3dfacb3d36095599b1a3687b41e017f3/doc/code-review.md?plain=1#L65
https://github.com/tacerus/yast.github.io/blob/00b19abf3dfacb3d36095599b1a3687b41e017f3/doc/contributing.md?plain=1#L49
Please be so kind and pay extra attention to those.

Best,
Georg

Signed-off-by: Georg <georg@lysergic.dev>