### PR TITLE
Revert #330

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.13.8)
+    nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.21.0)


### PR DESCRIPTION
## Problem

Jenkins is complaining about Ruby version [after updating nokogiri to the latest version](#330), as proposed by dependabot. See https://ci.opensuse.org/view/Yast/job/yast-yast.github.io-master/176/console

> Installing nokogiri 1.13.8 (x86_64-linux)
> Gem::RuntimeRequirementNotMetError: nokogiri requires Ruby version < 3.2.dev, >=
> 2.6. The current ruby version is 2.5.0.
> An error occurred while installing nokogiri (1.13.8), and Bundler cannot
> continue.

## Solution

Revert the update, since updating to a new Ruby version 

> would be complicated, the Jenkins workers run Leap with Ruby 2.5 — _@lslezak at IRC #yast channel._