### PR TITLE
Replace "boot-loader" with "bootloader"

### DIFF
--- a/_posts/2022-02-23-yast-development-start-2022.md
+++ b/_posts/2022-02-23-yast-development-start-2022.md
@@ -57,7 +57,7 @@ new features in YaST. Let's quickly go through a summary.
 - Adjusted [creation of snapshots in YaST](https://github.com/yast/yast-installation/pull/1020) for
   transactional systems like MicroOS.
 - New capability for roles and products to [specify a default
-  timeout](https://github.com/yast/yast-bootloader/pull/665) for the boot-loader configuration.
+  timeout](https://github.com/yast/yast-bootloader/pull/665) for the boot loader configuration.
 - Support for [switching themes](https://github.com/libyui/libyui/pull/65).
 - Adapted [handling of network configuration](https://github.com/yast/yast-network/pull/1282) if
   iBFT (iSCSI Boot Firmware Table) is used during installation.

--- a/_posts/2022-07-19-yast-development-2022-5.md
+++ b/_posts/2022-07-19-yast-development-2022-5.md
@@ -95,7 +95,7 @@ now access all this functionality:
 - Printers configuration
 - Administration of DNS server
 
-We are working on adapting more YaST modules as we write this. We hope to soon add boot-loader or
+We are working on adapting more YaST modules as we write this. We hope to soon add boot loader or
 Kdump configuration to the portfolio. Maybe even the YaST Partitioner if everything goes fine.
 
 On the other hand, we restructured the container images to rely on [SLE

--- a/_posts/2022-09-22-yast-development-2022-09.md
+++ b/_posts/2022-09-22-yast-development-2022-09.md
@@ -31,7 +31,7 @@ the package `yast-in-container` since it's not longer needed to enjoy the benefi
 containerized variant of YaST.
 
 But you may be wondering what those recent improvements are. First of all, now the respective YaST
-modules for configuring both Kdump and the boot-loader can handle transactional systems like ALP or
+modules for configuring both Kdump and the boot loader can handle transactional systems like ALP or
 MicroOS. On the other hand, the graphical Qt container was fixed to allow remote execution via SSH
 X11 forwarding. Again, that is useful in the context of ALP but not only there. That simple fix
 actually opens the door to full graphical administration of systems in which there is no graphical


### PR DESCRIPTION
According to the [SUSE Documentation Style Guide](https://documentation.suse.com/style/current/single-html/docu_styleguide/#app-terminology), use "boot loader" instead of "boot-loader".

