### PR TITLE
Marked Y2PROFILER env var as obsolete (bsc#1189647)

### DIFF
--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -142,6 +142,9 @@ yast-ruby-bindings:
 
   Starts the Ruby profiler if set to `1` or `true`.
 
+  _Dropped for distributions using Ruby 2.7 or newer.
+  Notice that SLE-15 SP4 / Leap 15.4 still use Ruby 2.5._
+
 - Y2DEBUGGER
 
   Can be set to `1`, `remote` or `manual`.

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -142,8 +142,7 @@ yast-ruby-bindings:
 
   Starts the Ruby profiler if set to `1` or `true`.
 
-  _Dropped for distributions using Ruby 2.7 or newer.
-  Notice that SLE-15 SP4 / Leap 15.4 still use Ruby 2.5._
+  _Dropped from SLE-15 SP5 / Leap 15.5 on._
 
 - Y2DEBUGGER
 

--- a/doc/environment-variables.md
+++ b/doc/environment-variables.md
@@ -138,7 +138,7 @@ yast-support:
 
 yast-ruby-bindings:
 
-- Y2PROFILER
+- ~~Y2PROFILER~~
 
   Starts the Ruby profiler if set to `1` or `true`.
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1189647

## Trello

https://trello.com/c/DLlTUGPz


## Problem

Crash when starting YaST (any module) with the `$Y2PROFILER` environment variable.


## Cause

Profiler support was dropped from Ruby with version 2.7:

https://github.com/ruby/ruby/blob/d92f09a5eea009fa28cd046e9d0eb698e3d94c5c/doc/NEWS-2.7.0#label-Stdlib+compatibility+issues+-28excluding+feature+bug+fixes-29

> profile.rb, Profiler__
>
> -  Removed from standard library. It was unmaintained since Ruby 2.0.0.


## Fix

Dropped profiler support from YaST as well.


## Related PR

Removing the `Y2PROFILER` env var from the code: https://github.com/yast/yast-ruby-bindings/pull/286

