### PR TITLE
Better ordering of topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ One engine used is [MkDocs][].
 
 Its main file is `mkdocs.yml`.
 
+See also [building-the-doc-locally.md](doc/building-the-doc-locally.md).
+
 [MkDocs]: https://www.mkdocs.org/
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -55,17 +55,19 @@ add the missing word to the custom dictionary.*
 Building the Documentation Locally
 ----------------------------------
 
-\[Here I pretend to know how MkDocs and Jekyll play together].
+We're using two engines: started with MkDocs but then we needed to import many
+blog posts from another site, and used Jekyll for that.
 
 ### MkDocs
 
-One engine used is [MkDocs][].
+One engine used is [MkDocs][]. It plays well with [Read the Docs][].
 
 Its main file is `mkdocs.yml`.
 
 See also [building-the-doc-locally.md](doc/building-the-doc-locally.md).
 
 [MkDocs]: https://www.mkdocs.org/
+[Read the Docs]: https://docs.readthedocs.io/en/stable/intro/getting-started-with-mkdocs.html
 
 ```sh
 python3 -m venv myvenv # set up an empty virtual environment

--- a/README.md
+++ b/README.md
@@ -51,3 +51,41 @@ as misspelled you can add it to the list.
 *Note: The installed default English dictionary used in CI might be different than
 in your system, the check may pass locally, but can fail at CI. In that case
 add the missing word to the custom dictionary.*
+
+Building the Documentation Locally
+----------------------------------
+
+\[Here I pretend to know how MkDocs and Jekyll play together].
+
+### MkDocs
+
+One engine used is [MkDocs][].
+
+Its main file is `mkdocs.yml`.
+
+[MkDocs]: https://www.mkdocs.org/
+
+```sh
+python3 -m venv myvenv # set up an empty virtual environment
+. myvenv/bin/activate  # activate it, running a new shell; use 'exit' when done
+pip install mkdocs
+
+mkdocs build           # -> site/
+mkdocs serve           # xdg-open http://127.0.0.1:8000/
+```
+
+### Jekyll
+
+Another engine that we use is [Jekyll][]. It [plays][] nicely with GitHub Pages.
+
+Its main file is `_config.yml`.
+
+[Jekyll]: https://jekyllrb.com/
+[plays]: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll
+
+```sh
+bundle install --path vendor/bundle
+bundle exec jekyll                  # pulled in by github-pages in Gemfile
+bundle exec jekyll build            # -> _site/
+bundle exec jekyll serve            # xdg-open http://127.0.0.1:4000/
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,31 @@
 site_name: Yast Documentation
 docs_dir: doc
 theme: readthedocs
+nav:
+  - README.md
+  - architecture.md
+  - auto-pkg-submission.md
+  - autoyast-development.md
+  - branching-how-to.md
+  - bug-tracking.md
+  - building-the-doc-locally.md
+  - ci-integration.md
+  - code-review.md
+  - contributing.md
+  - coveralls-integration.md
+  - debugging.md
+  - development.md
+  - development-tips.md
+  - environment-variables.md
+  - how-to-write-tests.md
+  - jenkins-integration.md
+  - localization.md
+  - maintenance-branches.md
+  - rubocop.md
+  - security-tips.md
+  - translation.md
+  - ui_inspector.md
+  - versioning.md
+  - WSL.md
+  - yast_is_open.md
+  - yast_team.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,31 +1,40 @@
 site_name: Yast Documentation
 docs_dir: doc
 theme: readthedocs
+# Introductory: you might want to read these first
 nav:
   - README.md
-  - architecture.md
-  - auto-pkg-submission.md
-  - autoyast-development.md
-  - branching-how-to.md
-  - bug-tracking.md
-  - building-the-doc-locally.md
-  - ci-integration.md
-  - code-review.md
-  - contributing.md
-  - coveralls-integration.md
-  - debugging.md
-  - development.md
-  - development-tips.md
-  - environment-variables.md
-  - how-to-write-tests.md
-  - jenkins-integration.md
-  - localization.md
-  - maintenance-branches.md
-  - rubocop.md
-  - security-tips.md
-  - translation.md
-  - ui_inspector.md
-  - versioning.md
-  - WSL.md
-  - yast_is_open.md
-  - yast_team.md
+  - About:
+      - "This team": yast_team.md
+      - "This docs": building-the-doc-locally.md
+  # Is it useful for a casual contributor?
+  - Introductory:
+      - yast_is_open.md
+      - architecture.md
+      - bug-tracking.md
+      - code-review.md
+      - contributing.md
+      - debugging.md
+      - development.md
+      - how-to-write-tests.md
+      - localization.md
+      # TODO: merge into localization.md
+      - translation.md
+      - versioning.md
+  # If you've been in the team for several years and still have to look this up,
+  # it means it's Advanced
+  - Advanced:
+      - auto-pkg-submission.md
+      - autoyast-development.md
+      - branching-how-to.md
+      - coveralls-integration.md
+      - ci-integration.md
+      - development-tips.md
+      - environment-variables.md
+      - jenkins-integration.md
+      - maintenance-branches.md
+      # Coding style is Introductory, but this one is for *adding* RuboCop
+      - rubocop.md
+      - security-tips.md
+      - ui_inspector.md
+      - WSL.md


### PR DESCRIPTION
## Problem

A colleague from another team was contributing to YaST, reading the docs, found many issues that we've been used to and overlooking

- https://github.com/yast/yast-kdump/issues/125
- https://trello.com/c/j7DQjsi6

And when I start fixing it I find that I am confused by the way this repo is transformed into the rendered website(s). So some basic meta-documentation is needed.

## Solution

Added a non-default `nav`igation section, and split the topics into **Introductory** vs **Advanced**


## Testing

Build locally, eyeball the list of topics

## Screenshots

![yast-github-io-new-nav](https://user-images.githubusercontent.com/102056/208456139-9801ded5-f3f0-4c02-a9d0-a4fb20f6671e.png)

