### PR TITLE
Added .readthedocs.yaml config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
## Problem

- The https://yastgithubio.readthedocs.io/en/latest/ page has not been updated for almost a year! :scream: 
- The builds are failing, see the [build log](https://app.readthedocs.org/projects/yastgithubio/builds/)
- The error is `The required .readthedocs.yaml configuration file was not found at repository's root.`

## Solution

- Add the required config file
- I basically reused the [template from the Readthedocs documentation ](https://docs.readthedocs.io/en/stable/config-file/index.html)
- Let's see if that helps...
