### PR TITLE
Ensure headings are fully visible

### DIFF
--- a/_sass/custom/_post.scss
+++ b/_sass/custom/_post.scss
@@ -24,18 +24,21 @@
   margin-bottom: $spacing-unit;
   h2 {
     font-size: 32px;
+    scroll-margin-top: 80px;
     @media (max-width: $screen-md-min) {
       font-size: 28px;
     }
   }
   h3 {
     font-size: 26px;
+    scroll-margin-top: 80px;
     @media (max-width: $screen-md-min) {
       font-size: 22px;
     }
   }
   h4 {
     font-size: 20px;
+    scroll-margin-top: 75px;
     @media (max-width: $screen-md-min) {
       font-size: 18px;
     }


### PR DESCRIPTION
## Problem

- The headings are not visible when using a page URL with anchor
- The page scrolls to the heading but because of the "floating" title bar it is not visible including the first line of the text below (it is below the title bar)
- This is confusing after clicking a link in another blog post

## Solution

- Add a scroll margin
- The fix was inspired by the Docusaurus CSS
- Documentation: https://developer.mozilla.org/en-US/docs/Glossary/Scroll_snap

## Testing

- Compare: https://yast.opensuse.org/blog/2024-06-28/agama-9#autoyast
- With: https://yast-branch-fixed-anchor-styling.surge.sh/blog/2024-06-28/agama-9#autoyast

## Screenshots

### Before

When using the `#autoyast` anchor the "AytoYaST Compatibility" heading is not visible:
![yast_blog_broken](https://github.com/user-attachments/assets/702b0bfd-e567-4ee9-a176-b8ad20baee70)

### After

When using the `#autoyast` anchor the heading and the text is fully visible:
![yast_blog_fixed](https://github.com/user-attachments/assets/2e277f9a-d7fa-494e-b448-4f6fe73c5bd3)
